### PR TITLE
increase time duration and implment timeout to prevent freeze

### DIFF
--- a/src/b3m.c
+++ b/src/b3m.c
@@ -58,16 +58,18 @@ int b3m_init(B3MData * r, const char* serial_port)
 	}
 
 	tio.c_cflag &= ~CBAUD;          // clear mask for setting baud rate
-	tio.c_cflag |= B3M_BAUD;        // set B3M baud
 	tio.c_cflag &= ~PARENB;         // set no parity
 	tio.c_cflag &= ~CSTOPB;         // 1 stop bit
 	tio.c_cflag &= ~CSIZE;          // clear mask for setting the data size
+	tio.c_cflag |= B3M_BAUD;        // set B3M baud
 	tio.c_cflag |= CS8;             // character size 8 bit
 	tio.c_cflag |= CREAD;           // enable receiver
 	tio.c_cflag |= CLOCAL;          // ignore modem status line
 	tio.c_iflag = IGNBRK | IGNPAR;  // ignore break condition and characer with parity error
 	tio.c_oflag = 0;                // raw mode
 	tio.c_lflag = 0;                // noncanonical input
+	tio.c_cc[VMIN] = 0;             // 0 return all else until n byte received
+	tio.c_cc[VTIME] = 1;            // 0 block forever else until n tenth second
 	tcflush(r->fd, TCIOFLUSH);      // flush current port setting
 
 	if (ioctl(r->fd, TCSETS, &tio)){

--- a/src/kondo_driver.cpp
+++ b/src/kondo_driver.cpp
@@ -248,7 +248,7 @@ class KondoDriver : public hardware_interface::RobotHW
 		}
 	}
 	ros::Time getTime() const {return ros::Time::now();}
-	ros::Duration getPeriod() const {return ros::Duration(0.01);}
+	ros::Duration getPeriod() const {return ros::Duration(0.02);}
 };
 
 int main(int argc, char **argv)


### PR DESCRIPTION
サーボ1個の場合安定して動作するが複数のサーボの場合通信がたまに固まってしまう。

対策して周期を遅くしまた固まった場合0.1s以内に通信しない場合、再度通信を行う。

@yasuohayashibara  ご確認をお願い致します。